### PR TITLE
Fix deprecated set output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ outputs:
   current_task_definition_path:
     description: Path to a copy of the current stable task-definition running on the cluster
 runs:
-  using: node12
+  using: node16
   main: dist/index.js

--- a/dist/build-task-definition.sh
+++ b/dist/build-task-definition.sh
@@ -18,16 +18,16 @@ set_outputs() {
   task_definition=$2
   running_stable_task_definition=$3
 
-  echo "::set-output name=should_deploy::$should_deploy"
+  echo "should_deploy=$should_deploy" >> "$GITHUB_OUTPUT"
 
   output_path="/tmp/task-definition.$INPUT_SERVICE.json"
   echo "$task_definition" > "$output_path"
-  echo "::set-output name=path::$output_path"
+  echo "path=$output_path" >> "$GITHUB_OUTPUT"
 
   if [ -n "$running_stable_task_definition" ]; then
     stable_output_path="/tmp/task-definition.stable.json"
     echo "$running_stable_task_definition" > "$stable_output_path"
-    echo "::set-output name=current_stable_task_definition_path::$stable_output_path"
+    echo "current_stable_task_definition_path=$stable_output_path" >> "$GITHUB_OUTPUT"
   fi
 }
 

--- a/src/build-task-definition.sh
+++ b/src/build-task-definition.sh
@@ -18,16 +18,16 @@ set_outputs() {
   task_definition=$2
   running_stable_task_definition=$3
 
-  echo "::set-output name=should_deploy::$should_deploy"
+  echo "should_deploy=$should_deploy" >> "$GITHUB_OUTPUT"
 
   output_path="/tmp/task-definition.$INPUT_SERVICE.json"
   echo "$task_definition" > "$output_path"
-  echo "::set-output name=path::$output_path"
+  echo "path=$output_path" >> "$GITHUB_OUTPUT"
 
   if [ -n "$running_stable_task_definition" ]; then
     stable_output_path="/tmp/task-definition.stable.json"
     echo "$running_stable_task_definition" > "$stable_output_path"
-    echo "::set-output name=current_stable_task_definition_path::$stable_output_path"
+    echo "current_stable_task_definition_path=$stable_output_path" >> "$GITHUB_OUTPUT"
   fi
 }
 


### PR DESCRIPTION
[sc-53588](https://app.shortcut.com/agendrix/story/53588/fixer-les-deprecations-en-ci)

- Migration de set-output vers la variable [$GITHUB_OUTPUT](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Migration de node 12 vers 16

J'ai tester avec le CI/CD du [site wordpress](https://github.com/agendrix/site-wordpress/actions/runs/4225101437)